### PR TITLE
Updating FSU-PRGE link

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@ We include readers for many corpora and writers for some popular formats, such a
     <td><a href="http://www.sciencedirect.com/science/article/pii/S1532046413001123">link to paper</a></td>
   </tr>
   <tr>
-    <td><a href="http://www.ebi.ac.uk/Rebholz-srv/CALBC/corpora/IeXML/goldcorpus/fsuprge.xml">FSU-PRGE</a></td>
+    <td><a href="https://julielab.de/Resources/FSU_PRGE.html">FSU-PRGE</a></td>
     <td>genes/proteins</td>
     <td><a href="http://aclweb.org/anthology/W/W10/W10-1838.pdf">link to paper</a></td>
   </tr>


### PR DESCRIPTION
The FSU PRGE protein corpus is now hosted by the creator - the JULIE Lab - itself. The download there has been cleaned, added documentation and, most important of all, contains all original levels of annotations.